### PR TITLE
Fixed call to get active pane URI

### DIFF
--- a/lib/pane-layout-formatter.coffee
+++ b/lib/pane-layout-formatter.coffee
@@ -67,7 +67,7 @@ module.exports =
     number_of_panes = open_panes.length
 
     # get current active item
-    active_item_uri = atom.workspace.getActivePaneItem()?.getUri()
+    active_item_uri = atom.workspace.getActivePaneItem()?.uri
 
     # TODO: consider refactoring these methods
     if columns in [4, 5]


### PR DESCRIPTION
getUri() doesnt seem to exist anymore, changed to uri property. 
